### PR TITLE
Trim option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ In your template use `translateCut:<number>` pipe right after `translate` pipe f
 
 ## Options
 
+### Separator
+
 If you are not satisfied with the basic settings of the separator (which is `|`), you can choose your own separator
 
 ```typescript
@@ -98,6 +100,24 @@ If you are not satisfied with the basic settings of the separator (which is `|`)
      NgxTranslateCutModule.forRoot({
       // Your separator in translation strings will be `*`
       separator: '*'
+    }),
+   ]
+  })
+```
+
+### Trim
+
+If you do not want to trim your translation strings before cutting you can set `trim` to `false` (default is `true`). See this [explanation](https://github.com/bartholomej/ngx-translate-cut/issues/62)...
+
+```typescript
+  import { NgxTranslateCutModule } from 'ngx-translate-cut';
+
+  @NgModule({
+   // ...
+   imports: [
+     // ...
+     NgxTranslateCutModule.forRoot({
+      trim: false
     }),
    ]
   })
@@ -145,7 +165,7 @@ yarn release:patch
 
 ## License
 
-Copyright &copy; 2023 [Lukas Bartak](http://bartweb.cz)
+Copyright &copy; 2024 [Lukas Bartak](http://bartweb.cz)
 
 Proudly powered by nature 🗻, wind 💨, tea 🍵 and beer 🍺 ;)
 

--- a/projects/ngx-translate-cut/README.md
+++ b/projects/ngx-translate-cut/README.md
@@ -145,7 +145,7 @@ yarn release:patch
 
 ## License
 
-Copyright &copy; 2023 [Lukas Bartak](http://bartweb.cz)
+Copyright &copy; 2024 [Lukas Bartak](http://bartweb.cz)
 
 Proudly powered by nature 🗻, wind 💨, tea 🍵 and beer 🍺 ;)
 

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.module.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.module.ts
@@ -5,17 +5,16 @@ import { NgxTranslateCutOptionsService } from './ngx-translate-cut.options.servi
 import { NgxTranslateCutPipe } from './ngx-translate-cut.pipe';
 
 export let FOR_ROOT_OPTIONS_TOKEN = new InjectionToken<NgxTranslateCutOptions>(
-  'forRoot() NgxTranslateCutOptionsService configuration.'
+  'forRoot() NgxTranslateCutOptionsService configuration.',
 );
 
 @NgModule({
-  declarations: [NgxTranslateCutPipe],
+  imports: [NgxTranslateCutPipe],
   exports: [NgxTranslateCutPipe],
-  providers: [NgxTranslateCutOptionsService],
 })
 export class NgxTranslateCutModule {
   public static forRoot(
-    options?: NgxTranslateCutOptions
+    options?: NgxTranslateCutOptions,
   ): ModuleWithProviders<NgxTranslateCutModule> {
     return {
       ngModule: NgxTranslateCutModule,

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.spec.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.spec.ts
@@ -1,0 +1,29 @@
+import { SEPARATOR } from './ngx-translate-cut.constants';
+import { ngxTranslateCutOptionsFactory } from './ngx-translate-cut.options.factory';
+import { NgxTranslateCutOptions } from './ngx-translate-cut.options.interface';
+import { NgxTranslateCutOptionsService } from './ngx-translate-cut.options.service';
+
+describe('ngxTranslateCutOptionsFactory', () => {
+  let factory: (options?: NgxTranslateCutOptions) => NgxTranslateCutOptionsService;
+
+  beforeEach(() => {
+    factory = ngxTranslateCutOptionsFactory;
+  });
+
+  it('should be created with default options', () => {
+    const result = factory();
+
+    expect(result.separator).toEqual(SEPARATOR);
+    expect(result.trim).toEqual(true);
+  });
+
+  it('should be created with custom options', () => {
+    const result = factory({
+      separator: '*',
+      trim: false,
+    });
+
+    expect(result.separator).toEqual('*');
+    expect(result.trim).toEqual(false);
+  });
+});

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.ts
@@ -2,13 +2,16 @@ import { NgxTranslateCutOptions } from './ngx-translate-cut.options.interface';
 import { NgxTranslateCutOptionsService } from './ngx-translate-cut.options.service';
 
 export const ngxTranslateCutOptionsFactory = (
-  options?: NgxTranslateCutOptions
+  options?: NgxTranslateCutOptions,
 ): NgxTranslateCutOptionsService => {
   const ngxTranslateCutOptionsService = new NgxTranslateCutOptionsService();
 
   if (options) {
     if (options.separator) {
       ngxTranslateCutOptionsService.separator = options.separator;
+    }
+    if (options.trim) {
+      ngxTranslateCutOptionsService.trim = options.trim;
     }
   }
   return ngxTranslateCutOptionsService;

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.factory.ts
@@ -10,7 +10,7 @@ export const ngxTranslateCutOptionsFactory = (
     if (options.separator) {
       ngxTranslateCutOptionsService.separator = options.separator;
     }
-    if (options.trim) {
+    if (options.trim !== undefined) {
       ngxTranslateCutOptionsService.trim = options.trim;
     }
   }

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.interface.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.interface.ts
@@ -1,3 +1,4 @@
 export interface NgxTranslateCutOptions {
   separator?: string;
+  trim?: boolean;
 }

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.service.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.service.ts
@@ -7,4 +7,8 @@ export class NgxTranslateCutOptionsService {
    * @returns separator – can be custom or predefined
    */
   public separator: string = SEPARATOR;
+  /**
+   * @returns trim – trim or not to trim, that is the question
+   */
+  public trim: boolean = true;
 }

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.service.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.options.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
 import { SEPARATOR } from './ngx-translate-cut.constants';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class NgxTranslateCutOptionsService {
   /**
    * @returns separator – can be custom or predefined

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.spec.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.spec.ts
@@ -1,19 +1,19 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { TestBed } from '@angular/core/testing';
 import { NgxTranslateCutOptionsService } from './ngx-translate-cut.options.service';
 import { NgxTranslateCutPipe } from './ngx-translate-cut.pipe';
 
-// const data: string = [1, 2, 3].map((i) => `text ${i}`).join('|');
 const data = 'first | second | last';
 
 describe('NgxTranslateCutPipe', () => {
   let pipe: NgxTranslateCutPipe;
+  let options: NgxTranslateCutOptionsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [NgxTranslateCutOptionsService]
+      imports: [NgxTranslateCutPipe],
+      providers: [NgxTranslateCutOptionsService],
     });
-    const options = TestBed.get(NgxTranslateCutOptionsService);
+    options = TestBed.inject(NgxTranslateCutOptionsService);
     pipe = new NgxTranslateCutPipe(options);
   });
 

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.spec.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.spec.ts
@@ -50,4 +50,32 @@ describe('NgxTranslateCutPipe', () => {
     expect(pipe.transform(null, 0))
       .toEqual('');
   });
+
+  describe('Separator', () => {
+    const dataWithCustomSeparator = 'first * second * last';
+
+    it('Should use custom separator', () => {
+      options.separator = '*';
+
+      expect(pipe.transform(dataWithCustomSeparator, 0))
+        .toEqual('first');
+      expect(pipe.transform(dataWithCustomSeparator, 1))
+        .toEqual('second');
+      expect(pipe.transform(dataWithCustomSeparator, 2))
+        .toEqual('last');
+    });
+  });
+
+  describe('Trim', () => {
+    it('Should omit trim', () => {
+      options.trim = false;
+
+      expect(pipe.transform(data, 0))
+        .toEqual('first ');
+      expect(pipe.transform(data, 1))
+        .toEqual(' second ');
+      expect(pipe.transform(data, 2))
+        .toEqual(' last');
+    });
+  });
 });

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.ts
@@ -12,7 +12,7 @@ export class NgxTranslateCutPipe implements PipeTransform {
     const cutIndex = Number(index);
     const splitted: string[] = value ? value.split(this.options?.separator || SEPARATOR) : null;
     const phrase: string = splitted ? splitted[cutIndex] : null;
-    const result = phrase ? phrase.trim() : '';
+    const result = phrase ? (this.options?.trim ? phrase.trim() : phrase) : '';
 
     return result;
   }

--- a/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.ts
+++ b/projects/ngx-translate-cut/src/lib/ngx-translate-cut.pipe.ts
@@ -4,6 +4,7 @@ import { NgxTranslateCutOptionsService } from './ngx-translate-cut.options.servi
 
 @Pipe({
   name: 'translateCut',
+  standalone: true,
 })
 export class NgxTranslateCutPipe implements PipeTransform {
   constructor(private options?: NgxTranslateCutOptionsService) {}


### PR DESCRIPTION
If you do not want to trim your translation strings before cutting you can set `trim` to `false` (default is `true`). See this [explanation](https://github.com/bartholomej/ngx-translate-cut/issues/62)...

resolves #62 